### PR TITLE
We are not using BuildRoot any more.

### DIFF
--- a/recipes/honey-gingerbread/honey-gingerbread.spec
+++ b/recipes/honey-gingerbread/honey-gingerbread.spec
@@ -19,7 +19,6 @@ Summary:        Traditional Czech Honey Gingerbread Recipe
 License:        NWL
 URL:            https://www.levneknihy.cz
 Source0:        honey-gingerbread-recipe.jpg
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 BuildRequires:  flour >= 500g, sugar >= 150g, honey >= 100g, butter >= 50g, eggs >= 2
 Requires:       bowl, refrigerator, rolling-pin, cookie-cutters, oven

--- a/recipes/spritzgebaeck/spritzgebaeck.spec
+++ b/recipes/spritzgebaeck/spritzgebaeck.spec
@@ -6,7 +6,6 @@ Summary:        German X-Mas Cookie recipe
 License:        Weber-Family-3rd-Gen
 URL:            http://weber-family-recipes.local/spritzgebaeck
 Source0:        spritzgebaeck-recipe.txt
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 BuildRequires:  flour >= 500g, sugar >= 250g, egg, hazelnuts, butter >= 250g
 Requires:       bowl, hands, oven, frost, meat-grinder


### PR DESCRIPTION
No, @simotek, not even on SLE-12.

See for example https://build.suse.de/package/show/SUSE:SLE-12:GA/tuned from SLE-12:GA, which doesn’t have `BuildRoot` and builds just fine.

Thanks to Ruediger Oertel for the information.